### PR TITLE
refactor(sentiment analyser): invoke spellCorrector on app start

### DIFF
--- a/app/constant/types.ts
+++ b/app/constant/types.ts
@@ -1,6 +1,8 @@
 const TYPES = {
   SentimentAnalysisService: Symbol.for('SentimentAnalysisService'),
   SentimentAnalyser: Symbol.for('SentimentAnalyser'),
+  Natural: Symbol.for('Natural'),
+  SpellCorrector: Symbol.for('SpellCorrector'),
 };
 
 export default TYPES;

--- a/app/container.ts
+++ b/app/container.ts
@@ -9,10 +9,10 @@ import { app, error } from './app';
 import { SentimentAnalysisService } from './service/sentimentAnalysis';
 import { SentimentAnalyser } from './lib/SentimentAnalyser';
 import { Natural } from './lib/Natural';
+import { SpellCorrectorFactory } from './lib/SpellCorrector';
 import TYPES from './constant/types';
 
 import './controller/listener';
-import { SpellCorrectorFactory } from './lib/SpellCorrector';
 
 const container = new Container();
 container

--- a/app/container.ts
+++ b/app/container.ts
@@ -8,9 +8,11 @@ dotenv.config();
 import { app, error } from './app';
 import { SentimentAnalysisService } from './service/sentimentAnalysis';
 import { SentimentAnalyser } from './lib/SentimentAnalyser';
+import { Natural } from './lib/Natural';
 import TYPES from './constant/types';
 
 import './controller/listener';
+import { SpellCorrectorFactory } from './lib/SpellCorrector';
 
 const container = new Container();
 container
@@ -19,6 +21,11 @@ container
 container
   .bind<SentimentAnalyser>(TYPES.SentimentAnalyser)
   .to(SentimentAnalyser);
+container.bind<Natural>(TYPES.Natural).to(Natural);
+container
+  .bind<SpellCorrectorFactory>(TYPES.SpellCorrector)
+  .to(SpellCorrectorFactory)
+  .inSingletonScope();
 
 const server = new InversifyExpressServer(container);
 

--- a/app/lib/Natural.ts
+++ b/app/lib/Natural.ts
@@ -1,0 +1,25 @@
+import { injectable } from 'inversify';
+// @ts-ignore
+import natural, { WordTokenizer, SentimentAnalyzer } from 'natural';
+
+@injectable()
+export class Natural {
+  private tokenizer: WordTokenizer;
+  private analyzer: SentimentAnalyzer;
+
+  constructor() {
+    // @ts-ignore
+    const { WordTokenizer, PorterStemmer, SentimentAnalyzer } = natural;
+    this.tokenizer = new WordTokenizer();
+    this.analyzer = new SentimentAnalyzer(
+      process.env.NATURAL_LANGUAGE,
+      PorterStemmer,
+      process.env.NATURAL_VOCABULARY,
+    );
+  }
+
+  public tokenize = (text: string): string[] => this.tokenizer.tokenize(text);
+
+  public getSentiment = (tokenized: string[]): number =>
+    this.analyzer.getSentiment(tokenized);
+}

--- a/app/lib/SentimentAnalyser.test.ts
+++ b/app/lib/SentimentAnalyser.test.ts
@@ -1,10 +1,13 @@
 import { SentimentAnalyser } from './SentimentAnalyser';
+import { Natural } from './Natural';
+import { SpellCorrectorFactory } from './SpellCorrector';
 
 describe('SentimentAnalyser', () => {
   let analyser: SentimentAnalyser;
 
   beforeEach(() => {
-    analyser = new SentimentAnalyser();
+    const spellCorrector = new SpellCorrectorFactory();
+    analyser = new SentimentAnalyser(new Natural(), spellCorrector);
   });
 
   it('should return positive sentiment', () => {

--- a/app/lib/SpellCorrector.ts
+++ b/app/lib/SpellCorrector.ts
@@ -1,0 +1,14 @@
+import { injectable } from 'inversify';
+import SpellCorrector from 'spelling-corrector';
+
+@injectable()
+export class SpellCorrectorFactory {
+  public corrector: any;
+
+  constructor() {
+    this.corrector = new SpellCorrector();
+    this.corrector.loadDictionary();
+  }
+
+  public correct = (text: string): string => this.corrector.correct(text);
+}


### PR DESCRIPTION
Sentiment Analyser performance improvement:
- extract Natural to a separate class and bind to container
- extract SpellCorrector to separate class and bind to container
  - bind SpellCorrector as singleton and instantiate on app start
  - load SpellCorrector dictionary on application start
    - improve performance by calling it at start instead of at every request